### PR TITLE
Added possibility to change marker size(float) and style

### DIFF
--- a/include/PandoraMonitoring.h
+++ b/include/PandoraMonitoring.h
@@ -205,7 +205,7 @@ public:
      *  @param  markerSize the marker size
      */
     TEveElement *AddMarkerToVisualization(const pandora::CartesianVector *const pMarkerPoint, const std::string &name, TEveElement *parent,
-        const Color color, const unsigned int markerSize);
+        const Color color, const float markerSize, const unsigned int markerStyle=20);
 
     /**
      *  @brief  Add line to visualization

--- a/include/PandoraMonitoringApi.h
+++ b/include/PandoraMonitoringApi.h
@@ -242,7 +242,7 @@ public:
      *  @param  markerSize the marker size
      */
     static void AddMarkerToVisualization(const pandora::Pandora &pandora, const pandora::CartesianVector *const pMarkerPoint,
-        const std::string &name, const Color color, const unsigned int markerSize);
+        const std::string &name, const Color color, const float markerSize, const unsigned int markerStyle=20);
 
     /**
      *  @brief  Add line to visualization

--- a/src/PandoraMonitoring.cc
+++ b/src/PandoraMonitoring.cc
@@ -907,7 +907,7 @@ TEveElement *PandoraMonitoring::VisualizeVertices(const pandora::VertexList *con
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 TEveElement *PandoraMonitoring::AddMarkerToVisualization(const CartesianVector *const pMarkerPoint, const std::string &name, TEveElement *parent,
-    const Color color, const unsigned int markerSize)
+    const Color color, const float markerSize, const unsigned int markerStyle)
 {
     this->InitializeEve();
 
@@ -920,7 +920,7 @@ TEveElement *PandoraMonitoring::AddMarkerToVisualization(const CartesianVector *
     const Color chosenColor((color < AUTO) ? color : ORANGE);
     pTEvePointSet->SetMarkerColor(GetROOTColor(chosenColor));
     pTEvePointSet->SetMarkerSize(markerSize);
-    pTEvePointSet->SetMarkerStyle(20);
+    pTEvePointSet->SetMarkerStyle(markerStyle);
 
     if (parent)
     {

--- a/src/PandoraMonitoringApi.cc
+++ b/src/PandoraMonitoringApi.cc
@@ -122,9 +122,9 @@ void PandoraMonitoringApi::VisualizeVertices(const pandora::Pandora &pandora, co
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 void PandoraMonitoringApi::AddMarkerToVisualization(const pandora::Pandora &pandora, const pandora::CartesianVector *const pMarkerPoint,
-    const std::string &name, const Color color, const unsigned int markerSize)
+    const std::string &name, const Color color, const float markerSize, const unsigned int markerStyle)
 {
-    PandoraMonitoring::GetInstance(pandora)->AddMarkerToVisualization(pMarkerPoint, name, NULL, color, markerSize);
+  PandoraMonitoring::GetInstance(pandora)->AddMarkerToVisualization(pMarkerPoint, name, NULL, color, markerSize, markerStyle);
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
The possibility to change the marker size now works for values <1 - changed from unsigned int to float. The change of style sort of works, but some root versions translate any marker style we use (including the default value of 20) into only two types of markers: cross and filled square. 