### PR TITLE
Update TTreeWrapper.cc

### DIFF
--- a/src/TTreeWrapper.cc
+++ b/src/TTreeWrapper.cc
@@ -266,7 +266,7 @@ TTreeWrapper::Branch<T>::Branch(TTree *pTree, const std::string &branchName) :
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 template <typename T>
-TTreeWrapper::Branch<T>::~Branch()
+TTreeWrapper::Branch<T>::~Branch<T>()
 {
 }
 


### PR DESCRIPTION
Fix error with clang11

```
PandoraPFANew/HEAD/PandoraMonitoring-origin/master/src/TTreeWrapper.cc:269:24: error: ISO C++ requires the name after '::~' to be found in the same scope as the name before '::~' [-Werror,-Wdtor-name]
```