### PR TITLE
Fix STATUS_CODE_NOT_INITIALIZED when visualizing clusters

### DIFF
--- a/src/PandoraMonitoring.cc
+++ b/src/PandoraMonitoring.cc
@@ -771,8 +771,18 @@ TEveElement *PandoraMonitoring::VisualizeClusters(
 
         std::stringstream sstr;
         sstr << starter << "Cluster\nEem(corr)=" << pCluster->GetElectromagneticEnergy() << "\nEhad(corr)=" << pCluster->GetHadronicEnergy()
-             << "\nNHits=" << pCluster->GetNCaloHits() << "\nInnerHitType=" << this->GetHitTypeString(pCluster->GetInnerLayerHitType())
-             << "\nOuterHitType=" << this->GetHitTypeString(pCluster->GetOuterLayerHitType());
+             << "\nNHits=" << pCluster->GetNCaloHits();
+
+        try
+        {
+            // inner & outer hit types are not mandatory for pandora::Cluster constructors
+            // and may throw STATUS_CODE_NOT_INITIALIZED if they're not set by the other pandora algorithms
+            sstr << "\nInnerHitType=" << this->GetHitTypeString(pCluster->GetInnerLayerHitType())
+                 << "\nOuterHitType=" << this->GetHitTypeString(pCluster->GetOuterLayerHitType());
+        }
+        catch (StatusCodeException &)
+        {
+        }
 
         const Color clusterColor((color != AUTO) ? color : (pCluster->GetAssociatedTrackList().empty()) ? LIGHTBLUE : MAGENTA);
 


### PR DESCRIPTION
The member variables `m_innerLayerHitType` and `m_outerLayerHitType` are not mandatory parameters for initializing `pandora::Cluster` objects:

(Clusters are created by the `pandora::ClusterManager`, and eventually the constructor of `pandora::Cluster` object)
https://github.com/PandoraPFA/PandoraSDK/blob/master/src/Objects/Cluster.cc#L232-L265
```c++
Cluster::Cluster(const object_creation::Cluster::Parameters &parameters) :
    m_nCaloHits(0),
    m_nPossibleMipHits(0),
    m_nCaloHitsInOuterLayer(0),
    m_electromagneticEnergy(0),
    m_hadronicEnergy(0),
    m_isolatedElectromagneticEnergy(0),
    m_isolatedHadronicEnergy(0),
    m_particleId(UNKNOWN_PARTICLE_TYPE),
    m_pTrackSeed(parameters.m_pTrack.IsInitialized() ? parameters.m_pTrack.Get() : nullptr),
    m_initialDirection(0.f, 0.f, 0.f),
    m_isDirectionUpToDate(false),
    m_isFitUpToDate(false),
    m_isAvailable(true)
{
    if (parameters.m_caloHitList.empty() && parameters.m_isolatedCaloHitList.empty() && !parameters.m_pTrack.IsInitialized())
        throw StatusCodeException(STATUS_CODE_INVALID_PARAMETER);

    if (parameters.m_pTrack.IsInitialized())
    {
        m_initialDirection = parameters.m_pTrack.Get()->GetTrackStateAtCalorimeter().GetMomentum().GetUnitVector();
        m_isDirectionUpToDate = true;
    }

    for (const CaloHit *const pCaloHit : parameters.m_caloHitList)
    {
        PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, this->AddCaloHit(pCaloHit));
    }

    for (const CaloHit *const pCaloHit : parameters.m_isolatedCaloHitList)
    {
        PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, this->AddIsolatedCaloHit(pCaloHit));
    }
}
```

Therefore, PandoraMonitoring sometimes throws `STATUS_CODE_NOT_INITIALIZED` when trying to visualize the clusters if some other Pandora algorithms did not initialize those parameters (for example, when the clusters are created via `ExternalClusteringAlgorithm` [[link](https://github.com/iLCSoft/DDMarlinPandora/blob/master/src/DDExternalClusteringAlgorithm.cc)]).

This PR fixes `STATUS_CODE_NOT_INITIALIZED` exception in such cases, especially when the calorimeter has no longitudinal segmentation and layer-related member variables are never used.